### PR TITLE
Groom format, Port demonstration IO to h5, and fix Episodicity

### DIFF
--- a/demonstration.py
+++ b/demonstration.py
@@ -34,7 +34,7 @@ class Demonstration(object):
                         self.rewards[index], self.terminals[index])
 
     def save(self, path):
-        with h5py.File(path, 'w') as f:
+        with h5py.File(path, 'w', libver='latest') as f:
             S = f.create_dataset('S', (len(self), ) + self.states[0].shape, dtype='uint8', compression='gzip', data=np.array(self.states))
             A = f.create_dataset('A', (len(self), ), dtype='uint8', data=np.array(self.actions))
             R = f.create_dataset('R', (len(self), ), dtype='int32', data=np.array(self.rewards))
@@ -82,7 +82,7 @@ class Demonstration(object):
     @staticmethod
     def load(path):
         demo = Demonstration()
-        with h5py.File(path, 'r') as f:
+        with h5py.File(path, 'r', libver='latest') as f:
             demo.rom = f['rom'].value
             demo.states = [s for s in np.array(f['S'])]  # don't worry, this is fine
             demo.actions = list(f['A'])

--- a/demonstration.py
+++ b/demonstration.py
@@ -9,7 +9,8 @@ class Demonstration(object):
 
     snapshot_interval = 1000
 
-    def __init__(self):
+    def __init__(self, rom=None):
+        self.rom = rom  # rom name as identified by ALE
         self.states = []
         self.actions = []
         self.rewards = []
@@ -35,6 +36,7 @@ class Demonstration(object):
 
     def save(self, path):
         with h5py.File(path, 'w', libver='latest') as f:
+            rom = f.create_dataset('rom', data=np.string_(self.rom))
             S = f.create_dataset('S', (len(self), ) + self.states[0].shape, dtype='uint8', compression='gzip', data=np.array(self.states))
             A = f.create_dataset('A', (len(self), ), dtype='uint8', data=np.array(self.actions))
             R = f.create_dataset('R', (len(self), ), dtype='int32', data=np.array(self.rewards))

--- a/demonstration.py
+++ b/demonstration.py
@@ -9,8 +9,9 @@ class Demonstration(object):
 
     snapshot_interval = 1000
 
-    def __init__(self, rom=None):
+    def __init__(self, rom=None, action_set=None):
         self.rom = rom  # rom name as identified by ALE
+        self.action_set = action_set # action indices for ALE
         self.states = []
         self.actions = []
         self.rewards = []
@@ -37,6 +38,7 @@ class Demonstration(object):
     def save(self, path):
         with h5py.File(path, 'w', libver='latest') as f:
             rom = f.create_dataset('rom', data=np.string_(self.rom))
+            action_set = f.create_dataset('action_set', (len(self.action_set), ), dtype='uint8', data=np.array(self.action_set))
             S = f.create_dataset('S', (len(self), ) + self.states[0].shape, dtype='uint8', compression='gzip', data=np.array(self.states))
             A = f.create_dataset('A', (len(self), ), dtype='uint8', data=np.array(self.actions))
             R = f.create_dataset('R', (len(self), ), dtype='int32', data=np.array(self.rewards))
@@ -86,6 +88,7 @@ class Demonstration(object):
         demo = Demonstration()
         with h5py.File(path, 'r', libver='latest') as f:
             demo.rom = f['rom'].value
+            demo.action_set = list(f['action_set'])
             demo.states = [s for s in np.array(f['S'])]  # don't worry, this is fine
             demo.actions = list(f['A'])
             demo.rewards = list(f['R'])

--- a/demonstration.py
+++ b/demonstration.py
@@ -37,12 +37,15 @@ class Demonstration(object):
 
     def save(self, path):
         with h5py.File(path, 'w', libver='latest') as f:
+            # metadata
             rom = f.create_dataset('rom', data=np.string_(self.rom))
             action_set = f.create_dataset('action_set', (len(self.action_set), ), dtype='uint8', data=np.array(self.action_set))
+            # transitions
             S = f.create_dataset('S', (len(self), ) + self.states[0].shape, dtype='uint8', compression='gzip', data=np.array(self.states))
             A = f.create_dataset('A', (len(self), ), dtype='uint8', data=np.array(self.actions))
             R = f.create_dataset('R', (len(self), ), dtype='int32', data=np.array(self.rewards))
             terminal = f.create_dataset('terminal', (len(self), ), dtype='b', data=np.array(self.terminals))
+            # emulator state
             snapshot = f.create_dataset('snapshot', (len(self.snapshots), ) + self.snapshots.values()[0].shape, dtype='uint8', data=np.array(self.snapshots.values()))
             snapshot_t = f.create_dataset('snapshot_t', (len(self.snapshots), ) , dtype='uint32', data=np.array(self.snapshots.keys()))
 

--- a/demonstration.py
+++ b/demonstration.py
@@ -7,7 +7,6 @@ Timestep = namedtuple('Timestep', ['state', 'action', 'reward', 'terminal'])
 
 class Demonstration(object):
 
-    snapshot_interval = 1000
 
     def __init__(self, rom=None, action_set=None):
         self.rom = rom  # rom name as identified by ALE

--- a/record.py
+++ b/record.py
@@ -118,8 +118,9 @@ def record(ale, demo, output, num_frames, num_episodes, snapshot_interval):
             demo.record_timestep(frame, action, reward)
             game_over = ale.game_over()
             if game_over:
-                # record final frame
+                # record end of episode w/ snapshot for resuming
                 demo.end_episode()
+                demo.snapshot(ale)
                 episodes += 1
                 print 'game over, score: {}'.format(score)
                 if num_episodes > 0 and episodes >= num_episodes:
@@ -134,7 +135,7 @@ def record(ale, demo, output, num_frames, num_episodes, snapshot_interval):
     except KeyboardInterrupt:
         pass
     finally:
-        demo.snapshot(ale)
+        demo.discard_incomplete_episode()
         demo.save(output)
 
 if __name__ == '__main__':

--- a/record.py
+++ b/record.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import time
+import os
 
 import ale_python_interface as ALE
 import click
@@ -68,6 +69,7 @@ def cli():
 @click.option('--episodes', default=0, help="Maximum number of episodes (game overs)")
 @click.option('--seed', default=0, help="Seed for emulator state")
 def record_new(rom, output, frames, episodes, seed):
+    rom_name = os.path.splitext(os.path.split(rom)[-1])[0]
     pygame.init()
     ale = ALE.ALEInterface()
     ale.setInt('random_seed', seed)
@@ -75,7 +77,7 @@ def record_new(rom, output, frames, episodes, seed):
     ale.setBool('color_averaging', False)
     ale.setBool('display_screen', True)
     ale.loadROM(rom)
-    demo = Demonstration()
+    demo = Demonstration(rom=rom_name)
     record(ale, demo, output, frames, episodes)
 
 @cli.command(name='resume')

--- a/record.py
+++ b/record.py
@@ -80,23 +80,22 @@ def record_new(rom, output, frames, episodes, seed):
 
 @cli.command(name='resume')
 @click.argument('partial_demo', type=click.Path(exists=True))
-@click.argument('output', type=click.Path())
+@click.argument('rom', type=click.Path(exists=True))
 @click.option('--frames', default=60 * 60 * 30, help="Maximum number of frames")
 @click.option('--episodes', default=0, help="Maximum number of episodes (game overs)")
-@click.option('--seed', default=0, help="Seed for emulator state")
-def resume(partial_demo, output, frames, episodes, rom):
+def resume(partial_demo, rom, frames, episodes):
     pygame.init()
     demo = Demonstration.load(partial_demo)
     ale = ALE.ALEInterface()
     ale.setFloat('repeat_action_probability', 0)
     ale.setBool('color_averaging', False)
     ale.setBool('display_screen', True)
-    if not rom:
-        ale.loadROM(demo.rom)
-    else:
-        ale.loadROM(rom)
+    ale.loadROM(rom)
+    # restore snapshot from original recording + begin new episode
+    # n.b. needed to preserve state from the original recording, like the seed
     demo.reset_to_latest_snapshot(ale)
-    record(ale, demo, output, frames, episodes)
+    ale.reset_game()
+    record(ale, demo, partial_demo, frames, episodes)
 
 def record(ale, demo, output, num_frames, num_episodes):
     keystates = {key: False for key in keys}

--- a/record.py
+++ b/record.py
@@ -75,7 +75,7 @@ def record_new(rom, output, frames, episodes, seed):
     ale.setBool('color_averaging', False)
     ale.setBool('display_screen', True)
     ale.loadROM(rom)
-    demo = Demonstration(rom, ale.getMinimalActionSet())
+    demo = Demonstration()
     record(ale, demo, output, frames, episodes)
 
 @cli.command(name='resume')
@@ -111,11 +111,11 @@ def record(ale, demo, output, num_frames, num_episodes):
             action = keystates_to_ale_action(keystates)
             reward = ale.act(action)
             score += reward
-            demo.record_timestep(frame, action, reward, False)
+            demo.record_timestep(frame, action, reward)
             game_over = ale.game_over()
             if game_over:
                 # record final frame
-                demo.record_timestep(ale.getScreenRGB(), 0, 0, True)
+                demo.end_episode()
                 episodes += 1
                 print 'game over, score: {}'.format(score)
                 if num_episodes > 0 and episodes >= num_episodes:

--- a/record.py
+++ b/record.py
@@ -77,7 +77,7 @@ def record_new(rom, output, frames, episodes, seed):
     ale.setBool('color_averaging', False)
     ale.setBool('display_screen', True)
     ale.loadROM(rom)
-    demo = Demonstration(rom=rom_name)
+    demo = Demonstration(rom=rom_name, action_set=ale.getMinimalActionSet())
     record(ale, demo, output, frames, episodes)
 
 @cli.command(name='resume')


### PR DESCRIPTION
Switch from pickling to hdf5 for loading and saving of demonstrations.
This is a more portable format.

TODO
- [x] decide/fix episodicity (loss of life vs. game over, etc.)
- [x] discard partial episodes (as poor estimates of return)
- [x] record terminal trace instead of boundary indices
- [x] ~~switch from lists to arrays (might give a speed-up)~~ nope, lists b.c. I'm lazy
- [x] batch h5 write for each episode? no, less natural for the demonstrator.
- [x] figure out if h5 can go faster. select latest library version. (could switch to `lzf` if need be.)
