### PR TITLE
Record Lives but Do Not End Episode on Loss of Life

### DIFF
--- a/demonstration.py
+++ b/demonstration.py
@@ -15,13 +15,15 @@ class Demonstration(object):
         self.actions = []
         self.rewards = []
         self.terminals = []
+        self.lives = []
         self.snapshots = {}
 
-    def record_timestep(self, screen_rgb, action, reward):
+    def record_timestep(self, screen_rgb, action, reward, lives):
         self.states.append(screen_rgb)
         self.actions.append(action)
         self.rewards.append(reward)
         self.terminals.append(False)
+        self.lives.append(lives)
 
     def end_episode(self):
         # TODO(shelhamer) save episode at a time?
@@ -47,6 +49,7 @@ class Demonstration(object):
             A = f.create_dataset('A', (len(self), ), dtype='uint8', data=np.array(self.actions))
             R = f.create_dataset('R', (len(self), ), dtype='int32', data=np.array(self.rewards))
             terminal = f.create_dataset('terminal', (len(self), ), dtype='b', data=np.array(self.terminals))
+            lives = f.create_dataset('lives', (len(self), ), dtype='uint8', data=np.array(self.lives))
             # emulator state
             snapshot = f.create_dataset('snapshot', (len(self.snapshots), ) + self.snapshots.values()[0].shape, dtype='uint8', data=np.array(self.snapshots.values()))
             snapshot_t = f.create_dataset('snapshot_t', (len(self.snapshots), ) , dtype='uint32', data=np.array(self.snapshots.keys()))
@@ -79,6 +82,7 @@ class Demonstration(object):
         del self.actions[t:]
         del self.rewards[t:]
         del self.terminals[t:]
+        del self.lives[t:]
 
     def reset_to_latest_snapshot(self, ale):
         latest = max(self.snapshots.keys())
@@ -108,5 +112,6 @@ class Demonstration(object):
             demo.actions = list(f['A'])
             demo.rewards = list(f['R'])
             demo.terminals = list(f['terminal'])
+            demo.lives = list(f['lives'])
             demo.snapshots = dict(zip(list(f['snapshot_t']), list(f['snapshot'])))
         return demo

--- a/record.py
+++ b/record.py
@@ -106,7 +106,6 @@ def record(ale, demo, output, num_frames, num_episodes, snapshot_interval):
     score = 0
     clock = pygame.time.Clock()
     episodes = 0
-    lives = ale.lives()
     try:
         while len(demo) < num_frames:
             if len(demo) % snapshot_interval == 0:
@@ -116,13 +115,11 @@ def record(ale, demo, output, num_frames, num_episodes, snapshot_interval):
             update_keystates(keystates)
             action = keystates_to_ale_action(keystates)
             reward = ale.act(action)
+            lives = ale.lives()
             score += reward
             demo.record_timestep(frame, action, reward, lives)
-            # end episode on game over or loss of life (by convention)
-            end_of_episode = ale.game_over() or ale.lives() < lives
-            if ale.lives() > lives:
-                lives = ale.lives()
-            if end_of_episode:
+            # end episode on game over
+            if ale.game_over():
                 # record terminal, take snapshot for resuming, advance to next
                 demo.end_episode()
                 demo.snapshot(ale)
@@ -136,7 +133,6 @@ def record(ale, demo, output, num_frames, num_episodes, snapshot_interval):
                     score = 0
                     time.sleep(5)
                     ale.reset_game()
-                lives = ale.lives()
             clock.tick(60)
             if len(demo) % 10000 == 0:
                 print 'FPS:', clock.get_fps()

--- a/record.py
+++ b/record.py
@@ -117,7 +117,7 @@ def record(ale, demo, output, num_frames, num_episodes, snapshot_interval):
             action = keystates_to_ale_action(keystates)
             reward = ale.act(action)
             score += reward
-            demo.record_timestep(frame, action, reward)
+            demo.record_timestep(frame, action, reward, lives)
             # end episode on game over or loss of life (by convention)
             end_of_episode = ale.game_over() or ale.lives() < lives
             if ale.lives() > lives:


### PR DESCRIPTION
For Atari, there is some sense in making game over the only terminal.
Lives are part of the state, at least visually, and could be modeled by policy or value.
It might make everything more time dependent and complicated, but so be it.

This is closer to real Atari, and by recording the trace of lives we can go back on this decision w/o losing our data.
